### PR TITLE
fix: type issues related to index route

### DIFF
--- a/src/components/homepage-quick-link.tsx
+++ b/src/components/homepage-quick-link.tsx
@@ -1,4 +1,4 @@
-import { DynamicMarquee } from "@/components/dynamic-marquee"
+import { DynamicMarquee } from "@components/dynamic-marquee.tsx"
 import { Link, type LinkProps } from "@tanstack/react-router"
 import { FiArrowUpRight } from "react-icons/fi"
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,7 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as ShowcaseRouteImport } from './routes/showcase'
 import { Route as DebugRouteImport } from './routes/debug'
 import { Route as SkillsRouteRouteImport } from './routes/skills/route'
-import { Route as IndexRouteRouteImport } from './routes/index/route'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as SkillsIndexRouteImport } from './routes/skills/index'
 import { Route as LegalIndexRouteImport } from './routes/legal/index'
 import { Route as ArchiveIndexRouteImport } from './routes/archive/index'
@@ -48,9 +48,9 @@ const SkillsRouteRoute = SkillsRouteRouteImport.update({
   path: '/skills',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRouteRoute = IndexRouteRouteImport.update({
+const IndexRoute = IndexRouteImport.update({
   id: '/',
-  path: '',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SkillsIndexRoute = SkillsIndexRouteImport.update({
@@ -156,6 +156,7 @@ const ArchiveItemsALRNAileronRouteRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
+  '/': typeof IndexRoute
   '/skills': typeof SkillsRouteRouteWithChildren
   '/debug': typeof DebugRoute
   '/showcase': typeof ShowcaseRoute
@@ -180,6 +181,7 @@ export interface FileRoutesByFullPath {
   '/archive/RCLA-studio-process-automation': typeof ArchiveItemsRCLAStudioProcessAutomationRouteRoute
 }
 export interface FileRoutesByTo {
+  '/': typeof IndexRoute
   '/debug': typeof DebugRoute
   '/showcase': typeof ShowcaseRoute
   '/library': typeof LibraryIndexRouteRoute
@@ -204,7 +206,7 @@ export interface FileRoutesByTo {
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
-  '/': typeof IndexRouteRoute
+  '/': typeof IndexRoute
   '/skills': typeof SkillsRouteRouteWithChildren
   '/debug': typeof DebugRoute
   '/showcase': typeof ShowcaseRoute
@@ -231,6 +233,7 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/'
     | '/skills'
     | '/debug'
     | '/showcase'
@@ -255,6 +258,7 @@ export interface FileRouteTypes {
     | '/archive/RCLA-studio-process-automation'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/'
     | '/debug'
     | '/showcase'
     | '/library'
@@ -304,7 +308,7 @@ export interface FileRouteTypes {
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRouteRoute: typeof IndexRouteRoute
+  IndexRoute: typeof IndexRoute
   SkillsRouteRoute: typeof SkillsRouteRouteWithChildren
   DebugRoute: typeof DebugRoute
   ShowcaseRoute: typeof ShowcaseRoute
@@ -349,9 +353,9 @@ declare module '@tanstack/react-router' {
     }
     '/': {
       id: '/'
-      path: ''
-      fullPath: ''
-      preLoaderRoute: typeof IndexRouteRouteImport
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/skills/': {
@@ -511,7 +515,7 @@ const SkillsRouteRouteWithChildren = SkillsRouteRoute._addFileChildren(
 )
 
 const rootRouteChildren: RootRouteChildren = {
-  IndexRouteRoute: IndexRouteRoute,
+  IndexRoute: IndexRoute,
   SkillsRouteRoute: SkillsRouteRouteWithChildren,
   DebugRoute: DebugRoute,
   ShowcaseRoute: ShowcaseRoute,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,12 +1,12 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { MainLayout } from "@/layouts/main.tsx";
-import { Divider } from "@/components/divider.tsx";
+import { MainLayout } from "@layouts/main.tsx";
+import { Divider } from "@components/divider.tsx";
 import { FiArrowDown, FiArrowUpRight } from "react-icons/fi";
-import "../../styles.css";
-import { QuickLink } from "./-quick-link.tsx";
+import "../styles.css";
+import { QuickLink } from "@components/homepage-quick-link.tsx";
 import { DirectionalArrow } from "@/icons/directional-arrow.tsx";
-import { Showcase } from "@/components/showcase.tsx";
-import { SkillsDirectory } from "@/components/skills.tsx";
+import { Showcase } from "@components/showcase.tsx";
+import { SkillsDirectory } from "@components/skills.tsx";
 
 export const Route = createFileRoute("/")({
   component: App,


### PR DESCRIPTION
The index route was previously in /routes/index/route.tsx (to colocate it with a component that's only used on that page). This seems to go against TanStack Router convention and was causing some typing issues, so it has now been taken out into /routes/index.tsx.

Squashed commit of the following:

commit 9e0add0c94a80847ce57cc3ad4c0f7b59b143114
Author: Christian Yalamov <chrisyalamov@gmail.com>
Date:   Sat Jan 3 01:32:27 2026 +0000

    moving index out into the src/ directory